### PR TITLE
Fix ahf_halos dataset description

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -2,7 +2,7 @@
     "ahf frontend": [
         {
             "code": "AHF",
-            "description": "Halos found using rockstar halo finder for dataset gizmo_64",
+            "description": "Halos found using AHF (AMIGA Halo Finder) for dataset gizmo_64",
             "filename": "ahf_halos",
             "size": "59 MB",
             "url": "http://yt-project.org/data/ahf_halos.tar.gz"


### PR DESCRIPTION
I was too careless not to change the halo finder name after copying.