### PR TITLE
Add a WarpX sample dataset with mesh refinement.

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -160,7 +160,7 @@
             "description": "A WarpX dataset with only one particle species",
             "filename": "LangmuirWave",
             "size": "41 MB",
-            "url": "http://yt-project.org/data/LangmuirWave.tar.gz"
+            "url": "http://yt-project.org/data/LangmuirWave_v2.tar.gz"
         },
         {
             "code": "WarpX",

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -175,7 +175,7 @@
             "filename": "Laser",
             "size": "1.7 MB",
             "url": "http://yt-project.org/data/Laser.tar.gz"
-        }
+        },
         {
             "code": "WarpX",
             "description": "A WarpX dataset with mesh refinement",

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -167,7 +167,7 @@
             "description": "A WarpX dataset with two particle species",
             "filename": "PlasmaAcceleration",
             "size": "6.4 MB",
-            "url": "http://yt-project.org/data/PlasmaAcceleration.tar.gz"
+            "url": "http://yt-project.org/data/PlasmaAcceleration_v2.tar.gz"
         },
         {
             "code": "WarpX",

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -176,6 +176,13 @@
             "size": "1.7 MB",
             "url": "http://yt-project.org/data/Laser.tar.gz"
         }
+        {
+            "code": "WarpX",
+            "description": "A WarpX dataset with mesh refinement",
+            "filename": "GaussianBeam",
+            "size": "6.2 MB",
+            "url": "http://yt-project.org/data/GaussianBeam.tar.gz"
+        }
     ],
     "chombo frontend": [
         {


### PR DESCRIPTION
I'm also changing it so that users get the "new" version of the PlasmaAcceleration dataset by default.