### PR TITLE
Add direct slack invite in place of modal

### DIFF
--- a/templates/base_withsignup.html
+++ b/templates/base_withsignup.html
@@ -1,57 +1,20 @@
 {% extends "base.html" %}
 {% block modals %}
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" role="dialog">
-    <div class="modal-dialog">
-      <!-- Modal content-->
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">Join us at Slack!</h4>
-          Thanks for requesting access to our community Slack chat. Please enter your name and e-mail address below to
-          request an invite. A moderator of our Slack community will send you an invite after reviewing your request.
-        </div>
-        <div class="modal-body">
-          <form role="form" data-async data-target="#myModal" id="signupForm">
-            <div class="form-group">
-               <label for="email">Your Email:</label>
-               <input type="email" class="form-control" id="email" placeholder="Enter email">
-            </div>
-            <div class="form-group">
-               <label for="name">Your Name:</label>
-               <input type="text" class="form-control" id="name" placeholder="Enter your name">
-            </div>
-            <div id="success"> </div> <!-- For success/fail messages -->
-            <input type="submit" value="Sign up" class="btn btn-info btn-block">
-          </form>
-        </div>
-      </div>
-    </div>
-  </div>
 {% endblock modals %}
 {% block customjs %}
 <script type="text/javascript">
-   jQuery(function($) {
-       $('form[data-async]').on('submit', function(event) {
-           var $form = $(this);
-           var $target = $($form.attr('data-target'));
-           var datainput = {
-               "email": $("input#email").val(),
-               "name": $("input#name").val()
-           };
-           $.ajax({
-               type: "POST",
-               url: "http://use.yt/slack_signup",
-               contentType: "application/json",
-               data: JSON.stringify(datainput),
-
-               success: function(data, status) {
-                   $target.modal('hide');
-               }
-           });
-
-           event.preventDefault();
-       });
-   }); 
+  $("#slack").click(function(event) {
+    $.ajax({
+      type: "GET",
+      url: "http://use.yt/slack_signup",
+      success: function(data, status) {
+        window.location.href = JSON.parse(data).url;
+      },
+      error: function (xhr, ajaxOptions, thrownError) {
+        alert("Something went wrong, please let us know on yt-users mailing list!");
+      }
+    });
+    event.preventDefault();
+  });
 </script>
 {% endblock customjs %}

--- a/templates/community.html
+++ b/templates/community.html
@@ -86,8 +86,7 @@
             <img src="img/irc_screenshot.jpg" class="pull-right img-rounded">
           </div>
             <div class="slack_signup_container">
-              <!-- Trigger the modal with a button -->
-              <button type="button" class="btn btn btn-large btn-primary" data-toggle="modal" data-target="#myModal">Join us @ Slack!</button>
+              <button type="button" class="btn btn btn-large btn-primary" id="slack">Join us @ Slack!</button>
             </div>
         </div>
       </div>

--- a/templates/development.html
+++ b/templates/development.html
@@ -38,8 +38,7 @@
                    margin-right: auto; display: block"></iframe>
         
             <div class="slack_signup_container">
-              <!-- Trigger the modal with a button -->
-              <button type="button" class="btn btn btn-large btn-primary" data-toggle="modal" data-target="#myModal">Join us @ Slack!</button>
+              <button type="button" class="btn btn btn-large btn-primary" id="slack">Join us @ Slack!</button>
             </div>
         </div>
       </div>


### PR DESCRIPTION
This removes the slack invite modal in favor of native slack's mechanism (invite via link).