### PR TITLE
use https links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
     <![endif]-->
 
     <!-- Custom styles for this template -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Inconsolata">
     {% block custom_scripts %}
     {% endblock custom_scripts %}
   </head>
@@ -43,7 +43,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a class="navbar-brand" href="http://yt-project.org/">yt project</a>
+              <a class="navbar-brand" href="https://yt-project.org/">yt project</a>
             </div>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
@@ -62,9 +62,9 @@
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Docs<b class="caret"></b></a>
                   <ul class="dropdown-menu">
-                    <li><a href="http://yt-project.org/docs/dev">Dev</a></li>
-                    <li><a href="http://yt-project.org/doc/">Stable</a></li>
-                    <li><a href="http://yt-project.org/docs/2.6">Legacy (2.x)</a></li>
+                    <li><a href="https://yt-project.org/docs/dev">Dev</a></li>
+                    <li><a href="https://yt-project.org/doc/">Stable</a></li>
+                    <li><a href="https://yt-project.org/docs/2.6">Legacy (2.x)</a></li>
                   </ul>
                 </li>
                 <li id="development"><a href="{{url_prefix}}development.html">Develop</a></li>
@@ -74,22 +74,22 @@
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Quick Links <b class="caret"></b></a>
                   <ul class="dropdown-menu">
                     <li class="dropdown-header">Learning</li>
-                    <li><a href="http://blog.yt-project.org/">yt Blog</a></li>
-                    <li><a href="http://yt-project.org/doc/quickstart/index.html">Quick Start</a></li>
-                    <li><a href="http://yt-project.org/doc/">Documentation</a></li>
-                    <li><a href="http://adsabs.harvard.edu/abs/2011ApJS..192....9T">ApJS paper</a>
+                    <li><a href="https://blog.yt-project.org/">yt Blog</a></li>
+                    <li><a href="https://yt-project.org/doc/quickstart/index.html">Quick Start</a></li>
+                    <li><a href="https://yt-project.org/doc/">Documentation</a></li>
+                    <li><a href="https://adsabs.harvard.edu/abs/2011ApJS..192....9T">ApJS paper</a>
                     <li class="divider"></li>
                     <li class="dropdown-header">Help!</li>
                     <li><a href="https://mail.python.org/mm3/mailman3/lists/yt-users.python.org/">Mailing List</a></li>
                     <li><a href="https://mail.python.org/mm3/mailman3/lists/yt-dev.python.org/">Development Mailing List</a></li>
-                    <li><a href="http://yt-project.org/irc.html">Live Chat</a></li>
-                    <li><a href="http://yt-project.org/slack.html">Join Slack</a></li>
-                    <li><a href="http://yt-project.org/docs/cheatsheet.pdf">Cheat sheet</a></li>
-                    <li><a href="http://yt-project.org/data">Sample Datasets Loadable by yt</a></li>
+                    <li><a href="https://yt-project.org/irc.html">Live Chat</a></li>
+                    <li><a href="https://yt-project.org/slack.html">Join Slack</a></li>
+                    <li><a href="https://yt-project.org/docs/cheatsheet.pdf">Cheat sheet</a></li>
+                    <li><a href="https://yt-project.org/data">Sample Datasets Loadable by yt</a></li>
                     <li class="divider"></li>
                     <li class="dropdown-header">Development</li>
                     <li><a href="https://github.com/yt-project/yt/issues/new">Report a Bug</a></li>
-                    <li><a href="http://ytep.readthedocs.org/en/latest/">YTEPs</a></li>
+                    <li><a href="https://ytep.readthedocs.org/en/latest/">YTEPs</a></li>
                     <li><a href="https://github.com/yt-project/yt">Project Page</a></li>
                   </ul>
                 </li>
@@ -118,7 +118,7 @@
         sc_partition=41;
         sc_security="3865f346";
       </script>
-      <script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+      <script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
     {% endblock footer %}
 
     {% block corejs %}

--- a/templates/community.html
+++ b/templates/community.html
@@ -9,7 +9,7 @@
             The yt project views community engagement, community involvement
             and community growth as absolutely essential to the health and
             success of a scientific software project.  We have
-            <a href="http://arxiv.org/abs/1301.7064">deliberately worked</a>
+            <a href="https://arxiv.org/abs/1301.7064">deliberately worked</a>
             to grow a helpful, sustainable community of peers and contributors.
           </p>
           <p class="lead">
@@ -57,7 +57,7 @@
         <div class="col-md-7">
           <h1>Chatting on IRC and Slack</h1>
           <p>
-            On <a href="http://freenode.org/">FreeNode</a> there is a channel
+            On <a href="https://freenode.org/">FreeNode</a> there is a channel
             called <span class="code">#yt</span> for chatting with other yt
             users.  You can join IRC using Adium, IRSSI, X-chat or any other IRC
             client by connecting to <span class="code">chat.freenode.org</a>.
@@ -66,7 +66,7 @@
           </p>
           <p>
             In case you don't have an IRC client, we also have a 
-            <a href="http://yt-project.org/irc.html">web client</a>
+            <a href="https://yt-project.org/irc.html">web client</a>
             that will connect you directly to our channel.
           </p>
           <p id="slack">
@@ -101,9 +101,9 @@
             The <a href="https://hub.yt/">yt Data Hub</a> is
             designed to be a place to facilitate easy sharing of data, projects
             of interest to others, as well as
-            <a href="http://jupyter.org/">Jupyter Notebooks</a>.  For very
+            <a href="https://jupyter.org/">Jupyter Notebooks</a>.  For very
             short form items, we also provide a
-            <a href="http://paste.yt-project.org/">pastebin</a>.
+            <a href="https://paste.yt-project.org/">pastebin</a>.
           </p>
         </div>
       </div>
@@ -112,7 +112,7 @@
         <div class="col-md-7">
           <h1>Social Networking</h1>
           <p>
-            yt has a presence on <a href="http://twitter.com/yt_astro">twitter</a>,
+            yt has a presence on <a href="https://twitter.com/yt_astro">twitter</a>,
             where occasional updates are posted.  Other places for short-form
             updates include the
             <a href="https://www.facebook.com/ytproject">facebook page</a>,
@@ -121,7 +121,7 @@
             hangouts, videos and live office hours are held.
           </p>
           <p>
-            yt also has a <a href="http://blog.yt-project.org/">blog</a>, where longer-form
+            yt also has a <a href="https://blog.yt-project.org/">blog</a>, where longer-form
             content can be found.  The blog itself is open for submissions -- all
             you have to do is visit the
             <a href="https://github.com/yt-project/blog">blog repository</a>,
@@ -225,7 +225,7 @@
 
           <p>The yt Community Code of Conduct was adapted
             from the 
-            <a href="http://www.astropy.org/about.html#codeofconduct">
+            <a href="https://www.astropy.org/code_of_conduct.html">
               Astropy Community Code of Conduct</a>, which was
               partially inspired by the PSF code of conduct.</p>
         </div>

--- a/templates/development.html
+++ b/templates/development.html
@@ -30,7 +30,7 @@
           </p>
         </div>
         <div class="col-md-5">
-          <iframe src="http://www.ohloh.net/p/129183/widgets/project_basic_stats.html"
+          <iframe src="https://www.ohloh.net/p/129183/widgets/project_basic_stats.html"
             scrolling="no" marginheight="0" marginwidth="0"
             style="margin-top:70px; height: 192px; background: white; 
                    width: 334px; border: none; border-radius: 12px; 
@@ -81,7 +81,7 @@
           </p>
           <p>
             In the documentation you can find an 
-            <a href="http://yt-project.org/doc/developing/index.html">an outline</a>
+            <a href="https://yt-project.org/doc/developing/index.html">an outline</a>
             of how to contribute changes, but here are some handy tips and
             tricks:
             <ul>
@@ -90,9 +90,9 @@
               <li>Push to your repository and issue pull requests from
               there.</li>
               <li>Add
-              <a href="http://yt-project.org/doc/developing/testing.html">tests</a>
+              <a href="https://yt-project.org/doc/developing/testing.html">tests</a>
               and documentation for new functionality.  The tests
-              <a href="http://tests.yt-project.org/">are run on every pull request</a>
+              <a href="https://tests.yt-project.org/">are run on every pull request</a>
               (yt-fido will let you know how your pull request does!)
               <li>If you get stuck or want feedback, drop by Slack, IRC, or the
               mailing list!</li>
@@ -118,9 +118,9 @@
             and breaking backwards compatibility.  Large-reaching design
             discussions and decisions are described in "yt Enhancement Proposals"
             (YTEPs).  These documents are stored in a
-            <a href="http://bitbucket.org/yt_analysis/ytep">repository</a>, they
+            <a href="https://github.com/yt-project/ytep">repository</a>, they
             are discussed both on the mailing list and through the process of
-            <a href="https://bitbucket.org/yt_analysis/ytep/pull-requests">pull requests</a>
+            <a href="https://github.com/yt-project/ytep/pulls">pull requests</a>
             and they are meant to be living documents that reflect how and why
             changes to fundamental components of yt are made.  The current set
             of all YTEPs can be found at
@@ -211,7 +211,7 @@
 
           <p>The yt Community Code of Conduct was adapted
             from the 
-            <a href="http://www.astropy.org/about.html#codeofconduct">
+            <a href="https://www.astropy.org/code_of_conduct.html">
               Astropy Community Code of Conduct</a>, which was
               partially inspired by the PSF code of conduct.</p>
         </div>

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -11,7 +11,7 @@
           <p class="lead">
             We welcome you to submit your own images made with yt from
             publications, talks, webpages, etc.  Just fork our 
-            <a href="http://github.com/yt-project/website/">repository</a>
+            <a href="https://github.com/yt-project/website/">repository</a>
             and issue a pull request with your image at the top of the page.
             Images should be about 400 pixels wide, and please include a link
             to any published work.

--- a/templates/index.html
+++ b/templates/index.html
@@ -103,25 +103,25 @@
               <span class="text-muted"> getting started.</span></h2>
           <p class="feature">
             To get started using yt to explore data, we provide resources
-            including <a href="http://yt-project.org/doc/">documentation</a>,
-            <a href="http://yt-project.org/workshop2012/">workshop material</a>,
+            including <a href="https://yt-project.org/doc/">documentation</a>,
+            <a href="https://yt-project.org/workshop2012/">workshop material</a>,
             and even a fully-executable
-            <a href="http://yt-project.org/doc/quickstart/index.html">quick start guide</a>
+            <a href="https://yt-project.org/doc/quickstart/index.html">quick start guide</a>
             demonstrating many of yt's capabilities.
           </p>
 
           <p class="feature">
             But if you just want to dive in and start using yt, we have a long
             list of
-            <a href="http://yt-project.org/doc/cookbook/index.html">recipes</a>
+            <a href="https://yt-project.org/doc/cookbook/index.html">recipes</a>
             demonstrating how to do various tasks in yt.  We even have 
-            <a href="http://yt-project.org/data">sample datasets</a> from all 
+            <a href="https://yt-project.org/data">sample datasets</a> from all 
             of our supported codes on which you can test these recipes.
             While yt should just <b>work</b> with your data, here are some 
-            <a href="http://yt-project.org/doc/examining/index.html">instructions</a>
+            <a href="https://yt-project.org/doc/examining/index.html">instructions</a>
             on loading in datasets from our supported codes and formats.
           </p>
-        <p><a class="btn btn-llg btn-primary yt-btn" href="http://yt-project.org/doc/quickstart/index.html">Get Started</a></p>
+        <p><a class="btn btn-llg btn-primary yt-btn" href="https://yt-project.org/doc/quickstart/index.html">Get Started</a></p>
         </div>
         <div class="col-md-5">
           <img class="featurette-image img-rounded img-responsive" src="img/analysis.jpg" alt="Dev workshop 2013">
@@ -146,9 +146,9 @@
           </p>
           <p class="feature">
             If you've got some code to share, or scripts that you'd like to
-            share, start up a repo on <a href="http://github.com/">GitHub
-            </a> or <a hreg="http://bitbucket.org/">Bitbucket</a> or share them
-            on our <a href="http://paste.yt-project.org/">pastebin</a>.  If you
+            share, start up a repo on <a href="https://github.com/">GitHub
+            </a> or <a hreg="https://bitbucket.org/">Bitbucket</a> or share them
+            on our <a href="https://paste.yt-project.org/">pastebin</a>.  If you
             have any trouble, drop by the
             <a href="https://mail.python.org/mm3/mailman3/lists/yt-users.python.org/">mailing list</a>
             and we'll be happy to help out.
@@ -165,24 +165,24 @@
           <p class="feature">
             If you're interested in getting started with helping out, the
             easiest way is to <a
-            href="http://github.com/yt-project/yt">Fork us
+            href="https://github.com/yt-project/yt">Fork us
             on GitHub</a>, check out the <a
-            href="http://yt-project.org/doc/developing/index.html">
+            href="https://yt-project.org/doc/developing/index.html">
             developer guide</a>, and stop by the <a
-            href="http://lists.spacepope.org/listinfo.cgi/yt-dev-spacepope.org">
+            href="https://lists.spacepope.org/listinfo.cgi/yt-dev-spacepope.org">
             development mailing list</a>.  yt is released under the 
             modified BSD License.
           </p>
           <p class="feature">
             There are lots
-            of <a href="http://yt-project.org/doc/developing/developing.html#technical-contributions">
+            of <a href="https://yt-project.org/doc/developing/developing.html#technical-contributions">
             fun projects to work on</a>, along with
             some <a href="https://github.com/yt-project/yt/issues">open
             issues</a>, and we'd particularly like if you'd help out
-            by <a href="http://yt-project.org/doc/developing/creating_frontend.html">
+            by <a href="https://yt-project.org/doc/developing/creating_frontend.html">
             adding support for a a new data format</a> or if you'd like to help
             out by shoring up support for a
-            <a href="http://yt-project.org/doc/reference/code_support.html">
+            <a href="https://yt-project.org/doc/reference/code_support.html">
             semi-supported output format</a>.
           </p>
           <p><a class="pull-left btn btn-llg btn-primary" href="development.html">Develop!</a></p>
@@ -201,7 +201,7 @@
           <h1>Get yt:<span class="text-muted"> all-in-one script.</h1>
           <p class="lead">
             yt is built on a stack of completely <a
-            href="http://www.fsf.org/working-together/">free and libre open source
+            href="https://www.fsf.org/working-together/">free and libre open source
             software</a>, with <b>no</b> proprietary dependencies. It provides its
             own install script, to assist with constructing an isolated
             environment that can be upgraded and operated independently of the
@@ -209,8 +209,8 @@
           </p>
           <p class="lead">
             If you use yt in a publication, we request that you please consider
-            citing <a href="http://adsabs.harvard.edu/abs/2011ApJS..192....9T">our method paper</a>
-            (<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2011ApJS..192....9T&data_type=BIBTEX&db_key=AST&nocookieset=1">BibTeX</a>).
+            citing <a href="https://adsabs.harvard.edu/abs/2011ApJS..192....9T">our method paper</a>
+            (<a href="https://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2011ApJS..192....9T&data_type=BIBTEX&db_key=AST&nocookieset=1">BibTeX</a>).
           </p>
           <p class="lead">
             Usually getting yt is as simple as running the installation script.
@@ -282,7 +282,7 @@
         <div class="container">
           <div class="row">
             <div class="col-lg-2">
-              <a href="http://www.nsf.gov/"><img src="img/nsf1.gif"
+              <a href="https://www.nsf.gov/"><img src="img/nsf1.gif"
                                                  width="150 px"
                                                  alt="nsf logo"></a>
             </div>
@@ -291,7 +291,7 @@
                  src="img/moore-logo.png" width="150 px" alt="GBMF logo"></a>
             </div>
             <div class="col-lg-2">
-              <a href="http://www.numfocus.org">
+              <a href="https://www.numfocus.org">
                 <img width="150 px" src="img/numfocus-fsa.png" alt="yt is a NumFOCUS fiscally sponsored project">
               </a>
             </div>
@@ -300,14 +300,14 @@
               yt has benefited from work supported by the National Science
               Foundation under Grant No.
               <a
-                href="http://www.nsf.gov/awardsearch/showAward?AWD_ID=1535651">1535651</a>
+                href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1535651">1535651</a>
               (<a
                 href="https://figshare.com/articles/SI2_SSE_yt_Reusable_Components_for_Simulating_Analyzing_and_Visualizing_Astrophysical_Systems/909413">proposal</a>).
               It has also benefited from work supported by the Gordon and Betty
               Moore Foundation's Data-Driven Discovery Initiative through Grant
               GBMF4561 to Matthew Turk.</p>
               <p>yt is a fiscally-sponsored project of <a
-                href="http://numfocus.org/">NumFOCUS</a>.
+                href="https://numfocus.org/">NumFOCUS</a>.
               </p></small>
             </div>
           </div>
@@ -319,7 +319,7 @@
         sc_partition=41;
         sc_security="3865f346";
       </script>
-      <script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+      <script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
 {% endblock footer %}
 {% block customjs %}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/atom-one-light.min.css">


### PR DESCRIPTION
This avoids mixed-content javascript errors when viewing yt-project.org over ssl. It also corrects a few links.