### PR TITLE
Replace try link with yt hub raft link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*.html
+/*.html
 data/index.html

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
                   aria-hidden="true"></span>&nbsp;&nbsp;Get yt!</a><br/>
           </div>
           <div class="glyph_container_button">
-            <a class="btn btn-lg btn-success btn-block" href="https://use.yt/">
+            <a class="btn btn-lg btn-success btn-block" href="https://girder.hub.yt/#raft/5b5b4686323d12000122aa8a">
                 <span class="glyph_button glyphicon glyphicon-play-circle"
                   aria-hidden="true"></span>&nbsp;&nbsp;Try yt!</a><br/>
           </div>


### PR DESCRIPTION
This makes the "try yt" link on the homepage work again.

I also fixed an issue with our gitignore that was causing *all* html files to match, not just the ones in the root directory.