### PR TITLE
Update KeplerianRing and add EAGLE_6 example to datafiles

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -749,10 +749,17 @@
         },
         {
             "code": "SWIFT",
-            "description": "Keplerian ring test. Output is in the Gadget HDF5 output format. Does not contain cosmological flags in header.",
+            "description": "Keplerian ring test. Output is in HDF5 output format. Does not contain cosmological flags in header.",
             "filename": "KeplerianRing",
-            "size": "1.5 MB",
+            "size": "765 kB",
             "url": "http://yt-project.org/data/KeplerianRing.tar.gz"
+        },
+        {
+            "code": "SWIFT",
+            "description": "Small cosmological volume from the EAGLE suite of simulations. This contains cosmological flags.",
+            "filename": "EAGLE_6",
+            "size": "70.5 MB",
+            "url": "http://yt-project.org/data/EAGLE_6.tar.gz"
         },
         {
             "code": "Gadget 3",


### PR DESCRIPTION
i've modified the `datafiles.json` to include the correct sizes for the examples.

I propose replacing the KeplerianRing currently with the new one which has the correct format, i.e `code=swift` in the header. (http://use.yt/upload/66a0c807)

I have also added the EAGLE_6 which is just a really small cosmo run starting with some reduced IC's from the EAGLE suite. (http://use.yt/upload/f585c33f)

These are both small, ~1mb and ~70mb so it would be quite nice to use these for the tests to make sure we are loading the files correctly.