### PR TITLE
Replace ohloh widgets with openhub.net

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -23,7 +23,7 @@
       </div>
 
       <div class="text-center">
-          <iframe src="http://www.ohloh.net/p/129183/widgets/project_factoids_stats.html" scrolling="no" marginHeight=0 marginWidth=0 style="height: 250px; width: 370px; border: none; background: white;"></iframe>
+          <script type='text/javascript' src='https://www.openhub.net/p/yt_amr/widgets/project_factoids_stats?format=js'></script>
       </div>
 
       <div class="row yt-package">

--- a/templates/development.html
+++ b/templates/development.html
@@ -30,12 +30,7 @@
           </p>
         </div>
         <div class="col-md-5">
-          <iframe src="https://www.ohloh.net/p/129183/widgets/project_basic_stats.html"
-            scrolling="no" marginheight="0" marginwidth="0"
-            style="margin-top:70px; height: 192px; background: white; 
-                   width: 334px; border: none; border-radius: 12px; 
-                   -webkit-border-radius: 12px; margin-left: auto;
-                   margin-right: auto; display: block"></iframe>
+          <script type='text/javascript' src='https://www.openhub.net/p/yt_amr/widgets/project_basic_stats?format=js'></script>
         
             <div class="slack_signup_container">
               <button type="button" class="btn btn btn-large btn-primary" id="slackSign">Join us @ Slack!</button>


### PR DESCRIPTION
Openhub is owned by the same company as Ohloh and seems to be its
new name based on https://en.wikipedia.org/wiki/Open_Hub#History

Widgets can be embedded using these HTML snippets:
https://www.openhub.net/p/yt_amr/widgets

Fixes #64