### PR TITLE
Disable warning in PyYAML

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -34,12 +34,12 @@ def page(name, output_name = None):
 
 @page('index')
 def index():
-    examples = yaml.load(open("examples.yaml", "r"))
+    examples = yaml.load(open("examples.yaml", "r"), Loader=yaml.SafeLoader)
     return {'title': 'Home', 'examples': examples}
 
 @page('gallery')
 def gallery():
-    entries = yaml.load(open("gallery.yaml", "r"))
+    entries = yaml.load(open("gallery.yaml", "r"), Loader=yaml.SafeLoader)
     return {'entries': entries}
 
 name_ignores = ["convert-repo"]
@@ -73,7 +73,7 @@ def community():
 
 @page('members')
 def members():
-    members = yaml.load(open("members.yaml", "r"))
+    members = yaml.load(open("members.yaml", "r"), Loader=yaml.SafeLoader)
     members.sort(key = lambda a: lastname_sort(a['name']))
     return {'members': members}
 
@@ -91,7 +91,7 @@ def data():
 
 @page('extensions')
 def extensions():
-    extensions = yaml.load(open("extensions.yaml", "r"))
+    extensions = yaml.load(open("extensions.yaml", "r"), Loader=yaml.SafeLoader)
     return {'extensions': extensions}
 
 @page('slack')


### PR DESCRIPTION
Since pyYAML 5.1 using yaml.load function without specifying the
Loader parameter has been deprecated.

```
generate.py:94: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  extensions = yaml.load(open("extensions.yaml", "r"))
generate.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  entries = yaml.load(open("gallery.yaml", "r"))
generate.py:37: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  examples = yaml.load(open("examples.yaml", "r"))
generate.py:76: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  members = yaml.load(open("members.yaml", "r"))
```

This uses the default loader called by `yaml.load` in 5.1 (yaml.FullLoader)
according to:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation