### PR TITLE
correct bytesize of amrvac jet dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -43,9 +43,9 @@
     "amrvac frontend": [
         {
             "code": "MPI-AMRVAC",
-            "description": "MHD Jet cloud run (2.5D). Unzips to 4KB",
+            "description": "MHD Jet cloud run (2.5D). Unzips to 8.2MB",
             "filename": "amrvac_jet_cylindrical_25D",
-            "size": "4KB",
+            "size": "6.1MB",
             "url": "http://yt-project.org/data/amrvac_mhd_jet.tar.gz"
         },
         {


### PR DESCRIPTION
For whatever reason, the "jet" dataset I originally was corrupted (the file was much tinier than the real thing).
I correct the size in the registry, and here's the correct file that should replace it 
http://use.yt/upload/178f766b