### PR TITLE
fix datafile URL for amrvac 3D cylindrical blast wave run

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -74,7 +74,7 @@
             "description": "3D cylindrical blast wave run. Unzips to 16MB",
             "filename": "amrvac_blastwave_cylindrical_3D",
             "size": "7.3MB",
-            "url": "http://yt-project.org/data/amrvac_bw_cylindrical_3D.tar.gz"
+            "url": "http://yt-project.org/data/amrvac_bw_cylindrical_3d.tar.gz"
         },
         {
             "code": "MPI-AMRVAC",


### PR DESCRIPTION
I noticed that the URL for this particular datafile was slightly incorrect. When I modified the name to be consistent with the other datafiles for this frontend, I had no issue downloading it. 