### PR TITLE
[HOLD] update description for blast wave dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -64,7 +64,7 @@
         },
         {
             "code": "MPI-AMRVAC",
-            "description": "3D cartesian blast wave run. Unzips to 3.8MB",
+            "description": "3D cartesian blast wave run, with associated parfile + a modifier parfile. Unzips to 3.8MB",
             "filename": "amrvac_blastwave_cartesian_3D",
             "size": "2.5MB",
             "url": "http://yt-project.org/data/amrvac_bw_cartesian_3d.tar.gz"


### PR DESCRIPTION
This addition provides test-material required by https://github.com/yt-project/yt/pull/2369

Reupload of the dataset, this time with parfiles attached to it. The total size doesn't change up to the description's precision.

The new dataset should override the existing one (although the main `.dat` file is actually a strict copy).
http://use.yt/upload/e4c6dc2e

