### PR TITLE
Add AdaptaHOP halo catalog

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -979,5 +979,14 @@
             "size": "1.7 MB",
             "url": "http://yt-project.org/data/ytdata_test.tar.gz"
         }
+    ],
+    "adaptahop frontend": [
+        {
+            "code": "AdaptaHOP",
+            "description": "Halo catalog for cosmological zoom output_00080 (see above). Unzips to 5.4 Mio",
+            "filename": "output_00080_halos",
+            "size": "5 MB",
+            "url": "http://yt-project.org/data/output_00080_halos.tar.gz"
+        }
     ]
 }


### PR DESCRIPTION
This provides a test dataset for AdaptaHOP (https://github.com/yt-project/yt/pull/2385) in pair with `output_00080` (http://yt-project.org/data/output_00080.tar.gz).

Dataset can be found at http://use.yt/upload/ef4cd901.
