### PR TITLE
New APEC emissivity file for yt 4.0

### DIFF
--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -61,6 +61,15 @@
         <tr><th>Auxiliary Data Files</th><th>Size (mb)</th><th>Description</th><th>Link</th></tr>
       </thead>
       <tbody>
+        <tr><td>apec_emissivity (v. 3)</td>
+          <td>243 KB</td>
+          <td>X-ray emissivity tables created
+          with <a href="http://www.atomdb.org/">AtomDB v3.0.9</a>
+          (for a collisionally ionized plasma), used for creating X-ray
+          fields. This needs to be multiplied by ne*nH instead of nH**2 (which
+          was the case in v. 2). Used in yt 4.0 and later.</td>
+          <td><a href="http://yt-project.org/data/apec_emissivity_v3.h5">download</a></td>
+        </tr>
         <tr><td>cloudy_emissivity (v. 2)</td>
             <td>2.1 MB</td>
             <td>X-ray emissivity tables created


### PR DESCRIPTION
This adds the necessary APEC emissivity file that is needed for yt-4.0 as per https://github.com/yt-project/yt/pull/2414