### PR TITLE
add tiny_fof_halos dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -628,6 +628,13 @@
     ],
     "halo_catalog frontends": [
         {
+            "code": "AdaptaHOP",
+            "description": "Halo catalog for cosmological zoom output_00080 (see below). Unzips to 5.4 MB",
+            "filename": "output_00080_halos",
+            "size": "5 MB",
+            "url": "http://yt-project.org/data/output_00080_halos.tar.gz"
+        },
+        {
             "code": "AHF",
             "description": "Halos found using AHF (AMIGA Halo Finder) for dataset gizmo_64",
             "filename": "ahf_halos",
@@ -664,7 +671,7 @@
         }
         {
             "code": "yt FoF",
-            "description": "47 halo catalogs with particle IDs made from the enzo_tiny_cosmology data with yt FoF.",
+            "description": "47 halo catalogs with particle IDs made from the enzo_tiny_cosmology data with yt FoF",
             "filename": "tiny_fof_halos",
             "side": "1.4 MB",
             "url": "http://yt-project.org/data/tiny_fof_halos.tar.gz"
@@ -994,13 +1001,4 @@
             "url": "http://yt-project.org/data/ytdata_test.tar.gz"
         }
     ],
-    "adaptahop frontend": [
-        {
-            "code": "AdaptaHOP",
-            "description": "Halo catalog for cosmological zoom output_00080 (see above). Unzips to 5.4 Mio",
-            "filename": "output_00080_halos",
-            "size": "5 MB",
-            "url": "http://yt-project.org/data/output_00080_halos.tar.gz"
-        }
-    ]
 }

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -677,15 +677,6 @@
             "url": "http://yt-project.org/data/tiny_fof_halos.tar.gz"
         }
     ],
-    "ytree frontend": [
-        {
-            "code": "ytree",
-            "description": "A small merger tree created using the Rockstar halo finder and consistent-trees merger tree code, then converted to the ytree format.",
-            "filename": "arbor",
-            "size": "5 MB",
-            "url": "http://yt-project.org/data/arbor.tar.gz"
-        }
-    ],
     "moab frontend": [
         {
             "code": "Moab",

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -626,7 +626,7 @@
             "url": "http://yt-project.org/data/sedov_tst_0004.tar.gz"
         }
     ],
-    "halo_catalog frontends": [
+    "halo catalog frontends": [
         {
             "code": "AdaptaHOP",
             "description": "Halo catalog for cosmological zoom output_00080 (see below). Unzips to 5.4 MB",

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -668,7 +668,7 @@
             "filename": "rockstar_halos",
             "size": "130 kB",
             "url": "http://yt-project.org/data/rockstar_halos.tar.gz"
-        }
+        },
         {
             "code": "yt FoF",
             "description": "47 halo catalogs with particle IDs made from the enzo_tiny_cosmology data with yt FoF",
@@ -991,5 +991,5 @@
             "size": "1.7 MB",
             "url": "http://yt-project.org/data/ytdata_test.tar.gz"
         }
-    ],
+    ]
 }

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -662,6 +662,13 @@
             "size": "130 kB",
             "url": "http://yt-project.org/data/rockstar_halos.tar.gz"
         }
+        {
+            "code": "yt FoF",
+            "description": "47 halo catalogs with particle IDs made from the enzo_tiny_cosmology data with yt FoF.",
+            "filename": "tiny_fof_halos",
+            "side": "1.4 MB",
+            "url": "http://yt-project.org/data/tiny_fof_halos.tar.gz"
+        }
     ],
     "ytree frontend": [
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pyyaml>=4.2b1
-GitPython==2.1.3
+GitPython==2.1.15
+gitdb2==2.0.6
+gitdb==0.6.4
 Jinja2>=2.10.1


### PR DESCRIPTION
Data has been uploaded. I also moved the adapahop entry into the halo catalogs section.

I've also removed the `ytree` dataset since I no longer intend to add the ytree frontend to the yt codebase.