### PR TITLE
add entry for ParticleCavity AMReX dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -263,6 +263,13 @@
             "filename": "GaussianBeam",
             "size": "6.2 MB",
             "url": "http://yt-project.org/data/GaussianBeam.tar.gz"
+        },
+        {
+            "code": "AMReX",
+            "description": "An AMRex particle dataset",
+            "filename": "ParticleCavity",
+            "size": "692KB",
+            "url": "http://yt-project.org/data/ParticleCavity.tar.gz"
         }
     ],
     "cf radial frontend": [


### PR DESCRIPTION
Add a AMReX dataset snapshot for future tests
(courtesy of @darylbond)
The dataset was used in this issue https://github.com/yt-project/yt/issues/2805

the tarball is here
http://use.yt/upload/77220711

@darylbond, may I ask you to check the description I wrote ?