### PR TITLE
Enzo-E MHD Sample Dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -439,6 +439,13 @@
             "filename": "ENZOP_DD0140",
             "size": "208 MB",
             "url": "https://yt-project.org/data/ENZOP_DD0140.tar.gz"
+        },
+        {
+            "code": "Enzo-E",
+            "description": "A dataset from a 3D MHD simulation of an Orszag-Tang Vortex.",
+            "filename": "ENZOE_orszag-tang_0.5",
+            "size": "25 MB",
+            "url": "https://yt-project.org/data/ENZOE_orszag-tang_0.5.tar.gz"
         }
     ],
     "exodus_ii frontend": [

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -425,16 +425,16 @@
             "url": "https://yt-project.org/data/SmartStars.tar.gz"
         }
     ],
-    "enzo_p frontend": [
+    "enzo_e frontend": [
         {
-            "code": "Enzo-P",
+            "code": "Enzo-E",
             "description": "A dataset from a 2D simulation of a high-pressure region shaped like the word \"Hi\".",
             "filename": "hello-0210",
             "size": "31 MB",
             "url": "https://yt-project.org/data/hello-0210.tar.gz"
         },
         {
-            "code": "Enzo-P",
+            "code": "Enzo-E",
             "description": "A cosmological dataset of a 3 Mpc/h comoving box with 64^3 grid cells and dark matter particles.",
             "filename": "ENZOP_DD0140",
             "size": "208 MB",


### PR DESCRIPTION
Introduced the sample MHD dataset for Enzo-E, [ENZOE_orszag-tang_0.5.tar.gz](https://github.com/yt-project/website/files/6533112/ENZOE_orszag-tang_0.5.tar.gz), which is used in an answer test being introduced by yt-project/yt#3274.

While I was doing this, I also updated all occurrences of "enzo_p"/"Enzo-P" to now read "enzo_e"/"Enzo-E", in accordance with yt-project/yt#3273.