### PR TITLE
Add special relativistic GAMER simulation

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -636,6 +636,13 @@
             "filename": "MHDOrszagTangVortex",
             "size": "8.7 MB",
             "url": "https://yt-project.org/data/MHDOrszagTangVortex.tar.gz"
+        },
+        {
+            "code": "GAMER",
+            "description": "Special relativistic hydrodynamics simulation of a jet hitting an interface between two fluids",
+            "filename": "JetICMWall",
+            "size": "2.3 MB",
+            "url": "https://yt-project.org/data/JetICMWall.tar.gz"
         }
     ],
     "gdf frontend": [

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -641,7 +641,7 @@
             "code": "GAMER",
             "description": "Special relativistic hydrodynamics simulation of a jet hitting an interface between two fluids",
             "filename": "JetICMWall",
-            "size": "2.3 MB",
+            "size": "2.3 GB",
             "url": "https://yt-project.org/data/JetICMWall.tar.gz"
         }
     ],


### PR DESCRIPTION
This adds a special relativistic simulation for the GAMER frontend. The file is already in the correct location on the server. 

This is to support https://github.com/yt-project/yt/pull/3033.