### PR TITLE
update tarballs in support to load_sample

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -510,9 +510,9 @@
         {
             "code": "FITS",
             "description": "Two X-ray images provided by <a href=\"http://hea-www.cfa.harvard.edu/~srandall/\">Scott Randall</a>, used in <a href=\"http://adsabs.harvard.edu/cgi-bin/bib_query?2011ApJ...737...99B\">Blanton, E.L., Randall, S.W., Clarke, T.E., et al. 2011, ApJ, 737, 99</a>.",
-            "filename": "A2052",
+            "filename": "xray_fits",
             "size": "507 kB",
-            "url": "https://yt-project.org/data/A2052.tar.gz"
+            "url": "https://yt-project.org/data/xray_fits.tar.gz"
         },
         {
             "code": "FITS",


### PR DESCRIPTION
fix #101
Most of the fix is to repackage tarballs, so here are the new ones:

| dataset | link |
| --------|-----|
| Sedov3D | http://use.yt/upload/db6a6b28 |
| ExodusII_tests | http://use.yt/upload/ca1842b0 |
| GaussianCloud | http://use.yt/upload/c3e5eb68 |
| sedov_tst_0004 | http://use.yt/upload/d7729706 |
| xray_fits | http://use.yt/upload/808c3513 |
| TurbBoxLowRes | http://use.yt/upload/d4393bcf |
| ParticleCavity | http://use.yt/upload/dbc6a778 |

note that in most cases I changed the extraction directory to match the tarball name (in some cases I _added_ a directory layer), but in one case I instead renamed the dataset to match the _existing_ extraction directory (`A2052 ` -> `xray_fits`), because I find that we might as well use the more descriptive name as a key since it already exists.
I'll open a companion PR on the main repo's side to reflect this change and update the hashes. (update: this is https://github.com/yt-project/yt/pull/3334)

*This PR exhausts the list of improperly formed tarballs, it will not be necessary to open new ones in the future*