### PR TITLE
fix a mistake in pointers to an AMRVAC dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -107,9 +107,9 @@
         {
             "code": "MPI-AMRVAC",
             "description": "A 2.5D MHD simulation of the solar atmosphere. Unzips to 456MB",
-            "filename": "solarprom2d",
+            "filename": "solar_prom2d",
             "size": "416MB",
-            "url": "https://yt-project.org/data/solarprom2d.tar.gz"
+            "url": "https://yt-project.org/data/solar_prom2d.tar.gz"
         }
     ],
     "athena frontend": [


### PR DESCRIPTION
this fixes a mistake a did in #97
I've checked that the correct url indeed leads somewhere, i.e. the tarball is correctly installed on the server, I just messed up the registration.