### PR TITLE
remove inconsistent/redundant file size unit in aux file array

### DIFF
--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -58,7 +58,7 @@
 
       <table class="table">
       <thead>
-        <tr><th>Auxiliary Data Files</th><th>Size (mb)</th><th>Description</th><th>Link</th></tr>
+        <tr><th>Auxiliary Data Files</th><th>Size</th><th>Description</th><th>Link</th></tr>
       </thead>
       <tbody>
         <tr><td>apec_emissivity (v. 3)</td>


### PR DESCRIPTION
Right now the array of auxiliary data files looks like this
<img width="71" alt="Screenshot 2021-06-05 at 22 54 53" src="https://user-images.githubusercontent.com/14075922/120905244-0c8ab680-c651-11eb-9307-9da6f6b6a030.png">

in fact, every single entry has a unit, making the one at the top of the column meaningless, so I removed it.