### PR TITLE
Add adaptahop dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -670,6 +670,13 @@
             "url": "https://yt-project.org/data/output_00080_halos.tar.gz"
         },
         {
+            "code": "AdaptaHOP",
+            "description": "Halo catalog for cosmological zoom output_00080 (see below). Unzips to 17 KB",
+            "filename": "output_00080_new_halos",
+            "size": "17 KB",
+            "url": "https://yt-project.org/data/output_00080_new_halos.tar.gz"
+        },
+        {
             "code": "AHF",
             "description": "Halos found using AHF (AMIGA Halo Finder) for dataset gizmo_64",
             "filename": "ahf_halos",


### PR DESCRIPTION
This adds a new AdaptaHOP dataset to be used with yt-project/yt#3254.
The dataset can be found at http://use.yt/upload/2920bca2.