### PR TITLE
Add LocBub_dust FLASH dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -622,7 +622,14 @@
             "filename": "DensTurbMag",
             "size": "1.6 MB",
             "url": "https://yt-project.org/data/DensTurbMag.tar.gz"
-        }
+        },
+	{
+	    "code": "FLASH",
+	    "description": "",
+	    "filename": "LocBub_dust",
+	    "size": "158 MB",
+	    "url": "https://yt-project.org/data/LocBub_dust.tar.gz"
+	}
     ],
     "gamer frontend": [
         {

--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -625,7 +625,7 @@
         },
 	{
 	    "code": "FLASH",
-	    "description": "",
+	    "description": "Credit: Jonathan Slavin",
 	    "filename": "LocBub_dust",
 	    "size": "158 MB",
 	    "url": "https://yt-project.org/data/LocBub_dust.tar.gz"


### PR DESCRIPTION
This is in support to https://github.com/yt-project/yt/pull/3683

The dataset was uploaded by Matt at http://use.yt/upload/d6e42681 (see https://github.com/yt-project/yt/pull/3683#issuecomment-1039499086)

@matthewturk, I've left the "description" field empty, feel free to fill it.
