### PR TITLE
Adding cholla dataset to website

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -311,6 +311,15 @@
             "url": "https://yt-project.org/data/C15-3D-3deg.tar.gz"
         }
     ],
+    "cholla frontend": [
+        {
+            "code": "cholla",
+            "description": "Small 3D Gradient Dataset",
+            "filename": "ChollaSimple",
+            "size": "164 kB",
+            "url": "https://yt-project.org/data/ChollaSimple.tar.gz"
+        }
+    ],
     "chombo frontend": [
         {
             "code": "Orion 2",


### PR DESCRIPTION
This adds a very simple 128**3 dataset for the cholla frontend to the website for testing.

I uploaded to the website using the:

`curl -T [datafile name].tar.gz http://use.yt/upload/` command, and the dataset exists at: `http://use.yt/upload/7adce3da`