### PR TITLE
Unpin GitPython and drop indirect deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 pyyaml>=4.2b1
-GitPython==2.1.15
-gitdb2==2.0.6
-gitdb==0.6.4
+GitPython
 Jinja2>=2.10.1
 importlib_resources>=1.3; python_version<'3.9'


### PR DESCRIPTION
We're doing only basic operations using GitPython. It's unlikely it's gonna break that easily. Also we're not explicitly using gitdb and gitdb2.