### PR TITLE
DOC: fix urls to YTEP domain

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -88,7 +88,7 @@
                     <li class="divider"></li>
                     <li class="dropdown-header">Development</li>
                     <li><a href="https://github.com/yt-project/yt/issues/new">Report a Bug</a></li>
-                    <li><a href="https://ytep.readthedocs.org/en/latest/">YTEPs</a></li>
+                    <li><a href="https://ytep.readthedocs.io/">YTEPs</a></li>
                     <li><a href="https://github.com/yt-project/yt">Project Page</a></li>
                   </ul>
                 </li>

--- a/templates/development.html
+++ b/templates/development.html
@@ -119,7 +119,7 @@
             and they are meant to be living documents that reflect how and why
             changes to fundamental components of yt are made.  The current set
             of all YTEPs can be found at
-            <a href="https://ytep.readthedocs.org/en/latest/">ytep.readthedocs.org</a>.
+            <a href="https://ytep.readthedocs.io/">ytep.readthedocs.org</a>.
           </p>
           <p>
             Because yt is used for

--- a/templates/members.html
+++ b/templates/members.html
@@ -9,7 +9,7 @@
             In September of 2014, a discussion on the yt-dev mailing list about
             project governance resulted in the development of a YTEP on the
             topic of
-            <a href="https://ytep.readthedocs.org/en/latest/YTEPs/YTEP-1776.html">project governance</a>.
+            <a href="https://ytep.readthedocs.io/en/master/YTEPs/YTEP-0000.html">project governance</a>.
             As an outcome of that, the community decided to establish a
             "membership" process, whereby individuals who had contributed in a
             significant way to the project were recognized and identified as


### PR DESCRIPTION
goal: fix #119
the link to YTEP 1776 (governance) is still broken, and I don't know where to find that page now