### PR TITLE
Adding basic gizmo_zeldovich entry. 

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -1024,6 +1024,13 @@
             "url": "https://yt-project.org/data/gizmo_mhd_mwdisk.tar.gz"
         },
         {
+            "code": "Gizmo",
+            "description": "Two snapshots of the Zeldovich Pancake test with cooling and metals from GIZMO_version=2022. Used for testing the updated file validation and cosmological header parsing.",
+            "filename": "gizmo_zeldovich",
+            "size": "28 MB",
+            "url": "https://yt-project.org/data/gizmo_zeldovich.tar.gz"
+        },
+        {
             "code": "Gasoline",
             "description": "DM-only Cosmology output",
             "filename": "agora_1e11.00400",


### PR DESCRIPTION
This dataset is intended for the new gizmo frontend test of the updated file validation and header cosmological variable parsing. See yt PR [#4470](https://github.com/yt-project/yt/pull/4470). I tried to provide a useful description, please feel free to improve it!

I uploaded the file to `use.yt/upload` following the example in PR #112. The generated url is [http://use.yt/upload/8473622c](http://use.yt/upload/8473622c).