### PR TITLE
Add 1d cylindrical boxlib dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -175,6 +175,13 @@
         },
         {
             "code": "Castro",
+            "description": "Sedov problem, 1-d dataset, 4 levels, cylindrical geometry",
+            "filename": "castro_sedov_1d_cyl_plt00150",
+            "size": "82 kB",
+            "url": "https://yt-project.org/data/castro_sedov_1d_cyl_plt00150.tar.gz"
+        },
+        {
+            "code": "Castro",
             "description": "Sedov problem, 2-d dataset, 4 levels",
             "filename": "castro_sedov_2d_cyl_in_cart_plt00150",
             "size": "4.6 MB",


### PR DESCRIPTION
This is to support https://github.com/yt-project/yt/pull/4758.

The dataset was uploaded with `yt upload` at http://use.yt/upload/afa4e1bd.