### PR TITLE
Parthenon Data Files

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -922,6 +922,29 @@
             "url": "https://yt-project.org/data/example-3d.tar.gz"
         }
     ],
+    "parthenon frontend": [
+        {
+            "code": "Parthenon",
+            "description": "A 2D advected disk with AMR from the Parthenon test suite.",
+            "filename": "parthenon_advection",
+            "size": "1.3 MB",
+            "url": "https://yt-project.org/data/parthenon_advection.tar.gz"
+        },
+        {
+            "code": "AthenaPK (Parthenon-Based)",
+            "description": "A 3D MHD simulation with AMR of a magnetized galaxy cluster.",
+            "filename": "athenapk_cluster",
+            "size": "1.4 MB",
+            "url": "https://yt-project.org/data/athenapk_cluster.tar.gz"
+        },
+        {
+            "code": "AthenaPK (Parthenon-Based)",
+            "description": "A 2D Hydro simulation of a Keplerian disk in uniform cylindrical geometry.",
+            "filename": "athenapk_disk",
+            "size": "13 KB",
+            "url": "https://yt-project.org/data/athenapk_disk.tar.gz"
+        }
+    ],
     "simulationio frontend": [
         {
             "code": "Einstein Toolkit",


### PR DESCRIPTION
Adding 3 tar files with example data from the AMR framework Parthenon and a derivative code AthenaPK.

Where do I upload the tarballs? They're extremely minimal, I've included them here:

[parthenon_advection.tar.gz](https://github.com/yt-project/website/files/14413500/parthenon_advection.tar.gz)
[athenapk_disk.tar.gz](https://github.com/yt-project/website/files/14413501/athenapk_disk.tar.gz)
[athenapk_cluster.tar.gz](https://github.com/yt-project/website/files/14413502/athenapk_cluster.tar.gz)
