### PR TITLE
Add datasets needed for testing yt-project/yt#5025

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -189,6 +189,20 @@
         },
         {
             "code": "Castro",
+            "description": "Sedov problem, 2-d dataset, 4 levels, cylindrical geometry",
+            "filename": "castro_sedov_2d_sph_in_cyl_plt00130",
+            "size": "558 kB",
+            "url": "https://yt-project.org/data/castro_sedov_2d_sph_in_cyl_plt00130.tar.gz"
+        },
+        {
+            "code": "Castro",
+            "description": "X-ray burst in a spherical shell, 2-d dataset",
+            "filename": "xrb_spherical_smallplt00010",
+            "size": "1.2 MB",
+            "url": "https://yt-project.org/data/xrb_spherical_smallplt00010.tar.gz"
+        },
+        {
+            "code": "Castro",
             "description": "3 levels, 2-d dataset, contains particles",
             "filename": "RT_particles.tar.gz",
             "size": "232 kb",


### PR DESCRIPTION
I tried uploading the datasets with `yt upload`, but it responds with a 500: Internal Server Error. They're pretty small, so I attached them here, along with their sha256 checksums:
[castro_sedov_2d_sph_in_cyl_plt00130.tar.gz](https://github.com/user-attachments/files/17320631/castro_sedov_2d_sph_in_cyl_plt00130.tar.gz), `ef4d081a2a2f8e10afe132768725c573631b82021e91f07782f1c1fbe043e2b5`
[xrb_spherical_smallplt00010.tar.gz](https://github.com/user-attachments/files/17320632/xrb_spherical_smallplt00010.tar.gz), `27ede5ed03f7c89b2afac03a368beb56d5f25f0c7c95b81f14f071a54a795783`