### PR TITLE
fix rendering of missing extension category

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -100,6 +100,7 @@ def extensions():
     return {'extensions': extensions['active'],
             'ytproject': extensions['ytproject'],
             'frontends': extensions['frontends'],
+            'related': extensions['related'],
             'legacyextensions': extensions['inactive']}
 
 @page('slack')


### PR DESCRIPTION
quick followup to fix a missing extensions element after #131 that i didn't catch locally.

bad (currently rendered version): 
![Screenshot from 2024-11-08 14-50-50](https://github.com/user-attachments/assets/d835787b-b9dd-4037-8181-c4f70150bfba)

good (locally rendered with this PR):
![Screenshot from 2024-11-08 14-51-34](https://github.com/user-attachments/assets/bf5bdafb-92b8-4276-8ce6-fce54719e3e8)

