### PR TITLE
decrease column size for logos on extensions page

### DIFF
--- a/templates/extensions.html
+++ b/templates/extensions.html
@@ -20,12 +20,12 @@
             <caption>Extension Packages</caption>
           {% for ext in extensions %}
             <tr>
-              <td class="col-lg-4">
+              <td class="col-lg-3">
                 {%if 'image' in ext%}
                   <img class="img-responsive" src="{{url_prefix}}/img/extensions/{{ext['image']}}"/>
                 {%endif%}
               </td>
-              <td class="col-lg-8">
+              <td class="col-lg-9">
                 <h3>{{ext['name']}}</h3>
                 <p>{{ext['description']}}</p>
                 <ul class="list-unstyled">
@@ -94,12 +94,12 @@
             <caption>Legacy Extensions (no longer maintained)</caption>
           {% for ext in legacyextensions %}
             <tr>
-              <td class="col-lg-4">
+              <td class="col-lg-3">
                 {%if 'image' in ext%}
                   <img class="img-responsive" src="{{url_prefix}}/img/extensions/{{ext['image']}}"/>
                 {%endif%}
               </td>
-              <td class="col-lg-8">
+              <td class="col-lg-9">
                 <h3>{{ext['name']}}</h3>
                 <p>{{ext['description']}}</p>
                 <ul class="list-unstyled">


### PR DESCRIPTION
Here's a screenshot -- ignore the missing images in my local build :) 

<img width="1524" height="1035" alt="Screenshot from 2025-07-17 16-11-37" src="https://github.com/user-attachments/assets/935818b1-3e5f-4416-a7e9-0bafe9d44dae" />


@brittonsmith how's that ratio?