### PR TITLE
Add RIOT/Parthenon curvilinear dataset

### DIFF
--- a/data/datafiles.json
+++ b/data/datafiles.json
@@ -957,6 +957,13 @@
             "filename": "athenapk_disk",
             "size": "13 KB",
             "url": "https://yt-project.org/data/athenapk_disk.tar.gz"
+        },
+		{
+            "code": "RIOT (Parthenon-Based)",
+            "description": "A 2D Hydro simulation of a Sedov blast in curvilinear geometry with AMR.",
+            "filename": "riot_sedov_curvlinear",
+            "size": "1.1 MB",
+            "url": "https://yt-project.org/data/riot_sedov_curvlinear.tar.gz"
         }
     ],
     "simulationio frontend": [


### PR DESCRIPTION
@Yurlungur I put 
```
A 2D Hydro simulation of a Sedov blast in curvilinear geometry with AMR.

Unlimited release LA-UR-23-24176
```
in the readme of the zip: http://use.yt/upload/c88d3f84
Does this fit/meet requirements?